### PR TITLE
Fix panic in root route handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,7 +33,7 @@ func main() {
 	})
 
 	e.GET("/", func(c echo.Context) error {
-		panic("test panic") // This is just for testing, remove in production
+		// Removed intentional panic
 		return c.String(http.StatusOK, "Hello!")
 	})
 


### PR DESCRIPTION
This PR removes the intentional panic in the root route handler that was causing the application to crash.

Changes:
- Removed `panic("test panic")` line from the root route handler
- Kept the panic recovery middleware intact for handling any other potential panics

This resolves the server crashes when accessing the root route.