### PR TITLE
Fix nil pointer dereference in root route handler

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,10 +33,7 @@ func main() {
 	})
 
 	e.GET("/", func(c echo.Context) error {
-		var x *int
-		x = new(int)
-		x = nil
-		fmt.Print(*x)
+		// Removed the nil pointer dereference that was causing the panic
 		return c.String(http.StatusOK, "Hello!")
 	})
 


### PR DESCRIPTION
This PR properly fixes the nil pointer dereference in the root route handler that was causing the application to crash.

The previous PR #1 only removed an explicit `panic()` call, but the route handler still contained code that would cause a nil pointer dereference:

```go
var x *int
x = new(int)
x = nil
fmt.Print(*x)  // This is causing the panic
```

This PR completely removes the problematic code, preventing any panic when accessing the root route.