### PR TITLE
fix: Add error handling for division by zero

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,7 +19,6 @@ func main() {
 			defer func() {
 				if r := recover(); r != nil {
 					stackTrace := string(debug.Stack())
-					// Store stack trace with timestamp
 					filename := fmt.Sprintf("panic_%d.txt", time.Now().Unix())
 					if err := os.WriteFile(filename, []byte(stackTrace), 0644); err != nil {
 						c.Logger().Errorf("Failed to write stack trace: %v", err)
@@ -33,11 +32,16 @@ func main() {
 	})
 
 	e.GET("/", func(c echo.Context) error {
-		// create some ppanic due to math
+		// Safe division with error handling
 		x := 10
 		y := 0
-		fmt.Print(x / y)
-		return c.String(http.StatusOK, "Hello!")
+		
+		if y == 0 {
+			return c.String(http.StatusBadRequest, "Error: Division by zero is not allowed")
+		}
+		
+		result := x / y
+		return c.String(http.StatusOK, fmt.Sprintf("Result: %d", result))
 	})
 
 	e.Logger.Fatal(e.Start(":8080"))


### PR DESCRIPTION
This PR fixes the division by zero error in the root handler by:

1. Adding proper error handling before division operation
2. Returning a proper HTTP 400 Bad Request response when division by zero is attempted
3. Maintaining the existing panic recovery middleware as a safety net

The changes prevent the application from panicking and provide a better user experience by returning an appropriate error message.